### PR TITLE
Add JWT filter with role-based authorization

### DIFF
--- a/src/main/java/com/example/ldapspring/Authorization/AuthenticationService.java
+++ b/src/main/java/com/example/ldapspring/Authorization/AuthenticationService.java
@@ -149,7 +149,7 @@ public class AuthenticationService {
     }
 
     // Role Management - PostgreSQL tabanlı yetkilendirme
-    private List<String> getUserRoles(String username) {
+    public List<String> getUserRoles(String username) {
         try {
             List<Role> roles = roleService.getUserRoles(username);
             if (roles.isEmpty()) {

--- a/src/main/java/com/example/ldapspring/Security/WebSecurityConfig.java
+++ b/src/main/java/com/example/ldapspring/Security/WebSecurityConfig.java
@@ -1,22 +1,34 @@
 package com.example.ldapspring.Security;
 
+import com.example.ldapspring.Authorization.AuthenticationService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 public class WebSecurityConfig {
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public JwtAuthenticationFilter jwtAuthenticationFilter(AuthenticationService authenticationService) {
+        return new JwtAuthenticationFilter(authenticationService);
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
-                        .anyRequest().permitAll()  // Şimdilik tüm isteklere izin ver
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                        .anyRequest().authenticated()
                 )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .httpBasic(basic -> basic.disable())
                 .formLogin(form -> form.disable());
 


### PR DESCRIPTION
## Summary
- Register a JWT authentication filter that loads user roles into the security context
- Configure security rules requiring ADMIN role for `/api/admin/**`
- Expose role lookup from `AuthenticationService`

## Testing
- `mvn -q test` *(fails: Could not transfer artifact spring-boot-starter-parent:pom:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_6899c967e2e0832fa17054f90758506d